### PR TITLE
Add note about cancelling dataflow streaming job in cleanup

### DIFF
--- a/gig03-02/tutorial.md
+++ b/gig03-02/tutorial.md
@@ -528,3 +528,9 @@ GCS のバケット削除
 ```bash
 gsutil rm -r gs://{{project-id}}-gig2/
 ```
+
+Dataflow Streaming Jobの停止
+```bash
+JOB_ID=$(gcloud dataflow jobs list --region us-central1 --status=active --filter="name=ps-to-bq-my-topic" | grep "JOB_ID" | cut -d" " -f2)
+[ -n "$JOB_ID" ] && gcloud dataflow jobs cancel $JOB_ID --region us-central
+```


### PR DESCRIPTION
本日はGIGの講習ありがとうございました。

最後、このプロジェクト自体は残して勉強に利用したく個別のクリーンアップを行ったのですが、ストリーミングのジョブは残ったままだったので課金されてしまう恐れがありました。

より安全かと思いましたので、ストリーミングのジョブが走っているならば削除するフローを追記しました。